### PR TITLE
Prepare DCC configuration for COI message filtering

### DIFF
--- a/src/configure/mod.rs
+++ b/src/configure/mod.rs
@@ -1,10 +1,11 @@
 use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
 
-use crate::constants::Event;
+use crate::constants::{Event, DC_CREATE_MVBOX};
 use crate::context::Context;
 use crate::dc_e2ee::*;
 use crate::dc_loginparam::*;
 use crate::dc_tools::*;
+use crate::filter_mode::{get_filter_mode, FilterMode};
 use crate::imap::*;
 use crate::job::*;
 use crate::oauth2::*;
@@ -81,7 +82,6 @@ pub fn dc_stop_ongoing_process(context: &Context) {
 // the other dc_job_do_DC_JOB_*() functions are declared static in the c-file
 #[allow(non_snake_case, unused_must_use)]
 pub unsafe fn dc_job_do_DC_JOB_CONFIGURE_IMAP(context: &Context, _job: &Job) {
-    let flags: libc::c_int;
     let mut success = false;
     let mut imap_connected_here = false;
     let mut smtp_connected_here = false;
@@ -554,17 +554,15 @@ pub unsafe fn dc_job_do_DC_JOB_CONFIGURE_IMAP(context: &Context, _job: &Job) {
                                                 smtp_connected_here = true;
                                                 if !s.shall_stop_ongoing {
                                                     progress!(context, 900);
-                                                    flags = if 0
-                                                        != context
-                                                            .sql
-                                                            .get_config_int(context, "mvbox_watch")
-                                                            .unwrap_or_else(|| 1)
-                                                        || 0 != context
-                                                            .sql
-                                                            .get_config_int(context, "mvbox_move")
-                                                            .unwrap_or_else(|| 1)
+                                                    let flags = if context
+                                                        .sql
+                                                        .get_config_int(context, "mvbox_watch")
+                                                        .unwrap_or(1)
+                                                        != 0
+                                                        || get_filter_mode(context)
+                                                            == FilterMode::Deltachat
                                                     {
-                                                        0x1
+                                                        DC_CREATE_MVBOX as i32
                                                     } else {
                                                         0
                                                     };

--- a/src/context.rs
+++ b/src/context.rs
@@ -20,6 +20,7 @@ use crate::types::*;
 use crate::x::*;
 use std::ptr;
 
+use crate::filter_mode::get_filter_mode;
 use std::path::PathBuf;
 
 pub struct Context {
@@ -389,10 +390,7 @@ pub unsafe fn dc_get_info(context: &Context) -> *mut libc::c_char {
         .sql
         .get_config_int(context, "mvbox_watch")
         .unwrap_or_else(|| 1);
-    let mvbox_move = context
-        .sql
-        .get_config_int(context, "mvbox_move")
-        .unwrap_or_else(|| 1);
+    let mvbox_move = get_filter_mode(context);
     let folders_configured = context
         .sql
         .get_config_int(context, "folders_configured")
@@ -461,7 +459,7 @@ pub unsafe fn dc_get_info(context: &Context) -> *mut libc::c_char {
         inbox_watch,
         sentbox_watch,
         mvbox_watch,
-        mvbox_move,
+        mvbox_move.as_ref(),
         folders_configured,
         configured_sentbox_folder,
         configured_mvbox_folder,

--- a/src/dc_move.rs
+++ b/src/dc_move.rs
@@ -1,17 +1,17 @@
 use crate::constants::*;
 use crate::context::*;
+use crate::filter_mode::{get_filter_mode, FilterMode};
 use crate::job::*;
 use crate::message::*;
 use crate::param::Params;
 
 pub unsafe fn dc_do_heuristics_moves(context: &Context, folder: &str, msg_id: u32) {
-    if context
-        .sql
-        .get_config_int(context, "mvbox_move")
-        .unwrap_or_else(|| 1)
-        == 0
-    {
-        return;
+    match get_filter_mode(context) {
+        FilterMode::Deltachat => {}
+        _ => {
+            // either filtering is disabled (None) or filtering is performed by the COI server.
+            return;
+        }
     }
 
     if !dc_is_inbox(context, folder) && !dc_is_sentbox(context, folder) {

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -21,6 +21,7 @@ use crate::dc_securejoin::*;
 use crate::dc_strencode::*;
 use crate::dc_tools::*;
 use crate::error::Result;
+use crate::filter_mode::{get_filter_mode, FilterMode};
 use crate::job::*;
 use crate::message::*;
 use crate::param::*;
@@ -908,15 +909,17 @@ unsafe fn handle_reports(
                 }
             }
 
-            if 0 != mime_parser.is_send_by_messenger || 0 != mdn_consumed {
+            /* Move the MDN away to the chats folder.  We do this for:
+            - Consumed or not consumed MDNs from other messengers
+            - Consumed MDNs from normal MUAs
+            Unconsumed MDNs from normal MUAs are _not_ moved.
+            NB: we do not delete the MDN as it may be used by other clients */
+            if mime_parser.is_send_by_messenger != 0 || mdn_consumed != 0 {
                 let mut param = Params::new();
                 param.set(Param::ServerFolder, server_folder.as_ref());
                 param.set_int(Param::ServerUid, server_uid as i32);
-                if 0 != mime_parser.is_send_by_messenger
-                    && 0 != context
-                        .sql
-                        .get_config_int(context, "mvbox_move")
-                        .unwrap_or_else(|| 1)
+                if mime_parser.is_send_by_messenger != 0
+                    && get_filter_mode(context) == FilterMode::Deltachat
                 {
                     param.set_int(Param::AlsoMove, 1);
                 }

--- a/src/filter_mode.rs
+++ b/src/filter_mode.rs
@@ -1,0 +1,60 @@
+use crate::error::Error;
+use std::convert::TryFrom;
+use std::default::Default;
+
+/// Specifies how incoming chat messages should be filtered.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum FilterMode {
+    /// Do not move chat messages out of the Inbox.
+    None,
+
+    /// Let Deltachat move chat messages from Inbox to a configured folder. Requires no server-side
+    /// COI support. This is the default behaviour.
+    Deltachat,
+
+    /// Let the COI server move chat messages to the standard COI/Chats folder.
+    CoiActive,
+
+    /// Let the COI server move chat messages to the standard COI/Chats folder after they have been
+    /// marked as seen.
+    CoiMoveAfterRead,
+}
+
+impl Default for FilterMode {
+    fn default() -> Self {
+        Self::Deltachat
+    }
+}
+
+impl TryFrom<&str> for FilterMode {
+    type Error = Error;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        match value {
+            "0" => Ok(Self::None),
+            "1" => Ok(Self::Deltachat),
+            "2" => Ok(Self::CoiActive),
+            "3" => Ok(Self::CoiMoveAfterRead),
+            _ => Err(format_err!("Unsupported FilterMode: {}", value).into()),
+        }
+    }
+}
+
+impl AsRef<str> for FilterMode {
+    fn as_ref(&self) -> &str {
+        match self {
+            Self::None => "0",
+            Self::Deltachat => "1",
+            Self::CoiActive => "2",
+            Self::CoiMoveAfterRead => "3",
+        }
+    }
+}
+
+pub fn get_filter_mode(context: &crate::context::Context) -> FilterMode {
+    context
+        .sql
+        .get_config(context, "mvbox_move")
+        .and_then(|s| FilterMode::try_from(s.as_str()).ok())
+        .unwrap_or_default()
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,6 +63,7 @@ mod dc_simplify;
 mod dc_strencode;
 mod dc_token;
 pub mod dc_tools;
+mod filter_mode;
 
 #[cfg(test)]
 mod test_utils;


### PR DESCRIPTION
The configuration setting for message filtering (`FilterMode`) is
persisted under config key `mvbox_move`. Previously, only values 0 and 1
were used. Extend it to support enabling server-side COI filtering.
Allowed values are now:

* None ("0"): Do not move chat messages out of the Inbox.

* Deltachat ("1"): Default behaviour. Deltachat will move chat messages
  from Inbox into the configured folder.

* CoiActive ("2"): COI server will move chat messages to standard
  COI/Chats folder.

* CoiMoveAfterRead ("3"): COI server will move chat messages to standard
  COI/Chats folder after they have been marked as seen.

Note: Message Delivery Notifications (MDN) are only moved when
`Deltachat` option is used. If `CoiActive` or `CoiMoveAfterRead` options
are used, we expect that the COI server performs the movement of MDNs.