### PR TITLE
Fixed Rust panic on SMTP errors

### DIFF
--- a/src/job.rs
+++ b/src/job.rs
@@ -185,7 +185,7 @@ impl Job {
                         let mut sock = context.smtp.lock().unwrap();
                         if 0 == sock.send(context, recipients_list, body) {
                             sock.disconnect();
-                            self.try_again_later(-1i32, Some(as_str(sock.error)));
+                            self.try_again_later(-1i32, sock.error.clone());
                         } else {
                             dc_delete_file(context, filename_s);
                             if 0 != self.foreign_id {
@@ -219,9 +219,9 @@ impl Job {
     }
 
     // this value does not increase the number of tries
-    fn try_again_later(&mut self, try_again: libc::c_int, pending_error: Option<&str>) {
+    fn try_again_later(&mut self, try_again: libc::c_int, pending_error: Option<String>) {
         self.try_again = try_again;
-        self.pending_error = pending_error.map(|s| s.to_string());
+        self.pending_error = pending_error;
     }
 
     #[allow(non_snake_case)]

--- a/src/smtp.rs
+++ b/src/smtp.rs
@@ -12,7 +12,7 @@ pub struct Smtp {
     transport_connected: bool,
     /// Email address we are sending from.
     from: Option<EmailAddress>,
-    pub error: *mut libc::c_char,
+    pub error: Option<String>,
 }
 
 impl Smtp {
@@ -22,7 +22,7 @@ impl Smtp {
             transport: None,
             transport_connected: false,
             from: None,
-            error: std::ptr::null_mut(),
+            error: None,
         }
     }
 


### PR DESCRIPTION
`sock.error` was prevously set by libetpan. Now it seems to be unused.