### PR TITLE
Refactor how COI configures Deltachat behavior

### DIFF
--- a/src/coi/config.rs
+++ b/src/coi/config.rs
@@ -21,20 +21,18 @@ impl CoiConfig {
     pub fn get_coi_deltachat_mode(&self) -> CoiDeltachatMode {
         if self.enabled {
             match self.message_filter {
-                CoiMessageFilter::None => CoiDeltachatMode::coi_disabled(),
-                CoiMessageFilter::Seen => CoiDeltachatMode {
-                    server_side_move_enabled: true,
-                    inbox_folder_override: Some("INBOX".to_string()),
-                    mvbox_folder_override: Some(self.coi_chats_folder.to_string()),
+                CoiMessageFilter::None => CoiDeltachatMode::Disabled,
+                CoiMessageFilter::Seen => CoiDeltachatMode::Enabled {
+                    inbox_folder_override: "INBOX".to_string(),
+                    mvbox_folder_override: self.coi_chats_folder.to_string(),
                 },
-                CoiMessageFilter::Active => CoiDeltachatMode {
-                    server_side_move_enabled: true,
-                    inbox_folder_override: Some(self.coi_chats_folder.to_string()),
-                    mvbox_folder_override: Some("INBOX".to_string()),
+                CoiMessageFilter::Active => CoiDeltachatMode::Enabled {
+                    inbox_folder_override: self.coi_chats_folder.to_string(),
+                    mvbox_folder_override: "INBOX".to_string(),
                 },
             }
         } else {
-            CoiDeltachatMode::coi_disabled()
+            CoiDeltachatMode::Disabled
         }
     }
 

--- a/src/coi/context_ext.rs
+++ b/src/coi/context_ext.rs
@@ -1,0 +1,77 @@
+use crate::coi::{CoiConfig, CoiDeltachatMode, CoiMessageFilter};
+use crate::context::*;
+use crate::job::*;
+use crate::param::*;
+
+const COI_METADATA_ENABLED: &str = "/private/vendor/vendor.dovecot/coi/config/enabled";
+const COI_METADATA_MESSAGE_FILTER: &str =
+    "/private/vendor/vendor.dovecot/coi/config/message-filter";
+
+impl Context {
+    pub fn get_coi_config(&self) -> Option<CoiConfig> {
+        self.inbox.read().unwrap().get_coi_config()
+    }
+
+    pub fn set_coi_enabled(&self, enable: bool, id: i32) {
+        let value = if enable { "yes" } else { "" };
+        let mut params = Params::new();
+        params.set_map(Param::Metadata, &[(COI_METADATA_ENABLED, value)]);
+        job_add(self, Action::SetMetadata, id as libc::c_int, params, 0);
+    }
+
+    pub fn set_coi_message_filter(&self, message_filter: CoiMessageFilter, id: i32) {
+        let mut params = Params::new();
+        params.set_map(
+            Param::Metadata,
+            &[(COI_METADATA_MESSAGE_FILTER, &message_filter.to_string())],
+        );
+        job_add(self, Action::SetMetadata, id as libc::c_int, params, 0);
+    }
+
+    pub fn get_coi_message_filter(&self, id: i32) {
+        let mut params = Params::new();
+        params.set(Param::Metadata, COI_METADATA_MESSAGE_FILTER);
+        job_add(self, Action::GetMetadata, id as libc::c_int, params, 0);
+    }
+
+    pub fn set_coi_deltachat_mode(&self, new_mode: CoiDeltachatMode) {
+        let arc = self.coi_deltachat_mode.clone();
+        let mut p = arc.lock().unwrap();
+        *p = new_mode;
+    }
+
+    pub fn get_mvbox_folder_override(&self) -> Option<String> {
+        self.with_coi_deltachat_mode(|mode| {
+            mode.get_mvbox_folder_override()
+                .map(|mvbox_override| mvbox_override.into())
+        })
+    }
+
+    pub fn has_mvbox_folder_override(&self) -> bool {
+        self.with_coi_deltachat_mode(|mode| mode.get_mvbox_folder_override().is_some())
+    }
+
+    /// DCC will move messages depending on two settings:
+    ///
+    /// * `mvbox_move` has to be enabled (set to "1") in the config, AND
+    ///
+    /// * `CoiDeltachatMode#is_server_side_move_enabled` has to be set to `false`.
+    pub fn is_deltachat_move_enabled(&self) -> bool {
+        if self.with_coi_deltachat_mode(|mode| mode.is_server_side_move_enabled()) {
+            false
+        } else {
+            self.sql
+                .get_config_int(self, "mvbox_move")
+                .map(|value| value == 1)
+                .unwrap_or(true)
+        }
+    }
+
+    /// Helper function that allows us to access the mutex protected `coi_deltachat_mode`
+    /// without having to write too verbose code.
+    pub fn with_coi_deltachat_mode<T>(&self, cb: impl FnOnce(&CoiDeltachatMode) -> T) -> T {
+        let arc = self.coi_deltachat_mode.clone();
+        let mode = arc.lock().unwrap();
+        cb(&mode)
+    }
+}

--- a/src/coi/deltachat_mode.rs
+++ b/src/coi/deltachat_mode.rs
@@ -1,0 +1,45 @@
+/// COI-related overrides for Deltachat.
+///
+/// In case a COI server with message filter "active" or "seen" is present, the server is
+/// responsible for moving message. In that case DeltaChat should be stopped from moving messages
+/// and the mvbox thread should listen for messages in the `mvbox_folder_override` and the inbox
+/// thread should listen for messages in `inbox_folder_override`.
+pub struct CoiDeltachatMode {
+    pub server_side_move_enabled: bool,
+    pub inbox_folder_override: Option<String>,
+    pub mvbox_folder_override: Option<String>,
+}
+
+impl CoiDeltachatMode {
+    pub fn coi_disabled() -> Self {
+        Self {
+            server_side_move_enabled: false,
+            inbox_folder_override: None,
+            mvbox_folder_override: None,
+        }
+    }
+
+    pub fn get_mvbox_folder_override(&self) -> Option<&str> {
+        self.mvbox_folder_override.as_ref().map(|s| s.as_ref())
+    }
+
+    pub fn get_inbox_folder_override(&self) -> Option<&str> {
+        self.inbox_folder_override.as_ref().map(|s| s.as_ref())
+    }
+
+    pub fn mvbox_folder_override_equals(&self, cmp: &str) -> bool {
+        self.get_mvbox_folder_override()
+            .map(|mvbox_folder_override| mvbox_folder_override == cmp)
+            .unwrap_or(false)
+    }
+
+    pub fn is_server_side_move_enabled(&self) -> bool {
+        self.server_side_move_enabled
+    }
+}
+
+impl Default for CoiDeltachatMode {
+    fn default() -> Self {
+        Self::coi_disabled()
+    }
+}

--- a/src/coi/deltachat_mode.rs
+++ b/src/coi/deltachat_mode.rs
@@ -1,45 +1,53 @@
 /// COI-related overrides for Deltachat.
-///
-/// In case a COI server with message filter "active" or "seen" is present, the server is
-/// responsible for moving message. In that case DeltaChat should be stopped from moving messages
-/// and the mvbox thread should listen for messages in the `mvbox_folder_override` and the inbox
-/// thread should listen for messages in `inbox_folder_override`.
-pub struct CoiDeltachatMode {
-    pub server_side_move_enabled: bool,
-    pub inbox_folder_override: Option<String>,
-    pub mvbox_folder_override: Option<String>,
+pub enum CoiDeltachatMode {
+    /// "Old" Deltachat behavior. No COI server, COI disabled, or COI message filter set to "none".
+    Disabled,
+
+    /// COI enabled and message filter set to "active" or "seen". The server is responsible for
+    /// moving message and DeltaChat should be stopped from moving messages.
+    /// The mvbox thread should listen for messages in the `mvbox_folder_override` and the inbox
+    /// thread should listen for messages in `inbox_folder_override`.
+    Enabled {
+        inbox_folder_override: String,
+        mvbox_folder_override: String,
+    },
 }
 
 impl CoiDeltachatMode {
-    pub fn coi_disabled() -> Self {
-        Self {
-            server_side_move_enabled: false,
-            inbox_folder_override: None,
-            mvbox_folder_override: None,
+    pub fn get_mvbox_folder_override(&self) -> Option<&str> {
+        match self {
+            Self::Disabled => None,
+            Self::Enabled {
+                ref mvbox_folder_override,
+                ..
+            } => Some(mvbox_folder_override),
         }
     }
 
-    pub fn get_mvbox_folder_override(&self) -> Option<&str> {
-        self.mvbox_folder_override.as_ref().map(|s| s.as_ref())
-    }
-
     pub fn get_inbox_folder_override(&self) -> Option<&str> {
-        self.inbox_folder_override.as_ref().map(|s| s.as_ref())
+        match self {
+            Self::Disabled => None,
+            Self::Enabled {
+                ref inbox_folder_override,
+                ..
+            } => Some(inbox_folder_override),
+        }
     }
 
     pub fn mvbox_folder_override_equals(&self, cmp: &str) -> bool {
-        self.get_mvbox_folder_override()
-            .map(|mvbox_folder_override| mvbox_folder_override == cmp)
-            .unwrap_or(false)
+        match self {
+            Self::Enabled {
+                ref mvbox_folder_override,
+                ..
+            } => mvbox_folder_override == cmp,
+            _ => false,
+        }
     }
 
     pub fn is_server_side_move_enabled(&self) -> bool {
-        self.server_side_move_enabled
-    }
-}
-
-impl Default for CoiDeltachatMode {
-    fn default() -> Self {
-        Self::coi_disabled()
+        match self {
+            Self::Disabled => false,
+            Self::Enabled { .. } => true,
+        }
     }
 }

--- a/src/coi/message_filter.rs
+++ b/src/coi/message_filter.rs
@@ -1,5 +1,5 @@
+use std::convert::{From, TryFrom};
 use strum_macros::{AsRefStr, Display, EnumString};
-use std::convert::{TryFrom, From};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Display, EnumString, AsRefStr)]
 #[strum(serialize_all = "snake_case")]
@@ -41,9 +41,9 @@ impl From<CoiMessageFilter> for i32 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::convert::From;
     use std::str::FromStr;
     use std::string::ToString;
-    use std::convert::From;
 
     #[test]
     fn test_to_string() {
@@ -78,7 +78,10 @@ mod tests {
     #[test]
     fn test_from_int() {
         assert_eq!(CoiMessageFilter::try_from(0i32), Ok(CoiMessageFilter::None));
-        assert_eq!(CoiMessageFilter::try_from(1i32), Ok(CoiMessageFilter::Active));
+        assert_eq!(
+            CoiMessageFilter::try_from(1i32),
+            Ok(CoiMessageFilter::Active)
+        );
         assert_eq!(CoiMessageFilter::try_from(2i32), Ok(CoiMessageFilter::Seen));
         assert!(CoiMessageFilter::try_from(3i32).is_err());
     }

--- a/src/coi/mod.rs
+++ b/src/coi/mod.rs
@@ -1,38 +1,8 @@
 pub mod config;
+pub mod context_ext;
+pub mod deltachat_mode;
 pub mod message_filter;
 
-pub use message_filter::CoiMessageFilter;
 pub use config::CoiConfig;
-use crate::context::*;
-use crate::job::*;
-use crate::param::*;
-
-const COI_METADATA_ENABLED: &str = "/private/vendor/vendor.dovecot/coi/config/enabled";
-const COI_METADATA_MESSAGE_FILTER: &str =
-    "/private/vendor/vendor.dovecot/coi/config/message-filter";
-
-impl Context {
-    pub fn get_coi_config(&self) -> Option<CoiConfig> {
-        self.inbox.read().unwrap().get_coi_config()
-    }
-
-    pub fn set_coi_enabled(&self, enable: bool, id: i32) {
-        let value = if enable { "yes" } else { "" };
-        let mut params = Params::new();
-        params.set_map(Param::Metadata, &[(COI_METADATA_ENABLED, value)]);
-        job_add(self, Action::SetMetadata, id as libc::c_int, params, 0);
-    }
-
-    pub fn set_coi_message_filter(&self, message_filter: CoiMessageFilter, id: i32) {
-        let mut params = Params::new();
-        params.set_map(Param::Metadata,
-                       &[(COI_METADATA_MESSAGE_FILTER, &message_filter.to_string())]);
-        job_add(self, Action::SetMetadata, id as libc::c_int, params, 0);
-    }
-
-    pub fn get_coi_message_filter(&self, id: i32) {
-        let mut params = Params::new();
-        params.set(Param::Metadata, COI_METADATA_MESSAGE_FILTER);
-        job_add(self, Action::GetMetadata, id as libc::c_int, params, 0);
-    }
-}
+pub use deltachat_mode::CoiDeltachatMode;
+pub use message_filter::CoiMessageFilter;

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,5 +1,4 @@
-use std::sync::{atomic::AtomicBool, atomic::Ordering, Arc, Condvar, Mutex, RwLock};
-
+use std::sync::{Arc, Condvar, Mutex, RwLock};
 use crate::chat::*;
 use crate::constants::*;
 use crate::contact::*;
@@ -20,6 +19,7 @@ use crate::webpush::WebPushConfig;
 use crate::x::*;
 use std::path::PathBuf;
 use std::ptr;
+use crate::coi::CoiDeltachatMode;
 
 pub struct Context {
     pub userdata: *mut libc::c_void,
@@ -43,10 +43,7 @@ pub struct Context {
     /// Mutex to avoid generating the key for the user more than once.
     pub generating_key_mutex: Mutex<()>,
     pub webpush_config: Option<WebPushConfig>,
-
-    is_coi_enabled: AtomicBool,
-
-    pub configured_mvbox_folder_override: Arc<Mutex<Option<String>>>, 
+    pub coi_deltachat_mode: Arc<Mutex<CoiDeltachatMode>>,
 }
 
 unsafe impl std::marker::Send for Context {}
@@ -82,29 +79,6 @@ impl Context {
             unsafe { cb(self, event, data1, data2) }
         } else {
             0
-        }
-    }
-
-    /// If this method is called with `is_coi_enabled` set to true,
-    /// this will stop Deltachat from moving messages.
-    pub fn override_deltachat_move(&self, is_coi_enabled: bool) {
-        self.is_coi_enabled.store(is_coi_enabled, Ordering::Release);
-    }
-
-    /// DCC will move messages depending on two settings:
-    ///
-    /// * `mvbox_move` has to be enabled (set to "1") in the config.
-    ///
-    /// * `Context::is_coi_enabled` MUST NOT be set to `true`. In case a COI enabled server is
-    ///   detected, deltachat is disabled from moving messages automatically.
-    pub fn is_deltachat_move_enabled(&self) -> bool {
-        if self.is_coi_enabled.load(Ordering::Acquire) {
-            false
-        } else {
-            self.sql
-                .get_config_int(self, "mvbox_move")
-                .map(|value| value == 1)
-                .unwrap_or(true)
         }
     }
 }
@@ -192,9 +166,7 @@ pub fn dc_context_new(
         perform_inbox_jobs_needed: Arc::new(RwLock::new(false)),
         generating_key_mutex: Mutex::new(()),
         webpush_config: None,
-        is_coi_enabled: AtomicBool::new(false),
-
-        configured_mvbox_folder_override: Arc::new(Mutex::new(None)),
+        coi_deltachat_mode: Arc::new(Mutex::new(CoiDeltachatMode::default())),
     }
 }
 
@@ -595,16 +567,14 @@ pub fn dc_is_sentbox(context: &Context, folder_name: impl AsRef<str>) -> bool {
 }
 
 pub(crate) fn dc_is_mvbox(context: &Context, folder_name: impl AsRef<str>) -> bool {
-    let arc = context.configured_mvbox_folder_override.clone();
-    let mutex_guard = arc.lock().unwrap();
-    if let Some(ref mvbox_folder_override) = *mutex_guard {
-        mvbox_folder_override == folder_name.as_ref()
-    } else {
+    let folder_name_as_ref = folder_name.as_ref();
+    if context.with_coi_deltachat_mode(|mode| mode.mvbox_folder_override_equals(folder_name_as_ref)) {
+        true
+    }
+    else {
         // no override
-        let mvbox_name = context.sql.get_config(context, "configured_mvbox_folder");
-
-        if let Some(name) = mvbox_name {
-            name == folder_name.as_ref()
+        if let Some(ref mvbox_name) = context.sql.get_config(context, "configured_mvbox_folder") {
+            mvbox_name == folder_name_as_ref
         } else {
             false
         }

--- a/src/context.rs
+++ b/src/context.rs
@@ -166,7 +166,7 @@ pub fn dc_context_new(
         perform_inbox_jobs_needed: Arc::new(RwLock::new(false)),
         generating_key_mutex: Mutex::new(()),
         webpush_config: None,
-        coi_deltachat_mode: Arc::new(Mutex::new(CoiDeltachatMode::default())),
+        coi_deltachat_mode: Arc::new(Mutex::new(CoiDeltachatMode::Disabled)),
     }
 }
 

--- a/src/imap.rs
+++ b/src/imap.rs
@@ -669,7 +669,7 @@ impl Imap {
                 match meta.entry.as_str() {
                     "/private/vendor/vendor.dovecot/coi/config/mailbox-root" => {
                         if coi.is_some() && meta.value.is_some() {
-                            coi.as_mut().unwrap().mailbox_root = meta.value.unwrap().to_string();
+                            coi.as_mut().unwrap().set_mailbox_root(&meta.value.unwrap());
                         }
                     }
                     "/private/vendor/vendor.dovecot/coi/config/enabled" => {

--- a/src/job.rs
+++ b/src/job.rs
@@ -6,7 +6,6 @@ use deltachat_derive::{FromSql, ToSql};
 use rand::{thread_rng, Rng};
 
 use crate::chat;
-use crate::coi::{CoiConfig, CoiMessageFilter};
 use crate::configure::*;
 use crate::constants::*;
 use crate::context::Context;
@@ -516,30 +515,28 @@ pub fn perform_imap_idle(context: &Context) {
     info!(context, 0, "INBOX-IDLE ended.");
 }
 
-pub fn perform_mvbox_fetch(context: &Context) {
-    let use_network = context
+fn mvbox_use_network(context: &Context) -> bool {
+    context
         .sql
         .get_config_int(context, "mvbox_watch")
-        .unwrap_or_else(|| 1);
+        .map(|value| value == 1)
+        .unwrap_or(true)
+}
 
+pub fn perform_mvbox_fetch(context: &Context) {
     context
         .mvbox_thread
         .write()
         .unwrap()
-        .fetch(context, use_network == 1);
+        .fetch(context, mvbox_use_network(context));
 }
 
 pub fn perform_mvbox_idle(context: &Context) {
-    let use_network = context
-        .sql
-        .get_config_int(context, "mvbox_watch")
-        .unwrap_or_else(|| 1);
-
     context
         .mvbox_thread
         .read()
         .unwrap()
-        .idle(context, use_network == 1);
+        .idle(context, mvbox_use_network(context));
 }
 
 pub fn interrupt_mvbox_idle(context: &Context) {
@@ -1030,70 +1027,18 @@ fn suspend_smtp_thread(context: &Context, suspend: bool) {
     }
 }
 
-struct DeltachatMode {
-    coi_enabled: bool,
-    inbox_folder: String,
-    configured_mvbox_folder_override: Option<String>,
-}
-
-fn determine_deltachat_mode(coi_config: &Option<CoiConfig>) -> DeltachatMode {
-    // If COI is unsupported or disabled, we poll from INBOX and do not override the `mvbox_move`
-    // settings. Otherwise we use "${MAILBOX_ROOT}/Chats" and "disable" `mvbox_move`, i.e.  let the
-    // server do the moving of messages.
-    match coi_config {
-        // COI is not supported.
-        | None
-
-        // COI is supported, but not enabled.
-        | Some(CoiConfig { enabled: false, .. })
-
-        // COI is supported and enabled, but COI message filter is set to "none". Messages as
-        // such will not be moved automatically from the INBOX, but DeltaChat is free to do so.
-        | Some(CoiConfig {
-            enabled: true,
-            message_filter: CoiMessageFilter::None,
-            ..
-        }) => DeltachatMode {
-            coi_enabled: false,
-            inbox_folder: "INBOX".into(),
-            configured_mvbox_folder_override: None},
-
-        // COI is supported and enabled, message filter is set to "seen".  The server will move the
-        // messages from INBOX to COI/Chats once they are marked as seen. We have to listen on
-        // INBOX. XXX: We also have to change the "configured_mvbox_folder" to point to
-        // "COI/Chats".
-        | Some(CoiConfig {
-            enabled: true,
-            message_filter: CoiMessageFilter::Seen,
-            mailbox_root
-        }) => DeltachatMode {
-            coi_enabled: true,
-            inbox_folder: "INBOX".into(),
-            configured_mvbox_folder_override: Some(format!("{}/Chats", mailbox_root))},
-
-        // Active COI message filter. The server will move messages.
-        Some(CoiConfig {
-            enabled: true,
-            message_filter: CoiMessageFilter::Active,
-            mailbox_root,
-        }) => DeltachatMode {
-            coi_enabled: true,
-            inbox_folder: format!("{}/Chats", mailbox_root),
-            configured_mvbox_folder_override: Some("INBOX".into())},
-    }
-}
-
 fn connect_to_inbox(context: &Context, inbox: &Imap) -> libc::c_int {
     let ret_connected = dc_connect_to_configured_imap(context, inbox);
     if 0 != ret_connected {
-        let deltachat_mode = determine_deltachat_mode(&context.get_coi_config());
 
-        // If `coi_enabled` is true, this will disable Deltachat from moving messages.
-        context.override_deltachat_move(deltachat_mode.coi_enabled);
-        inbox.set_watch_folder(deltachat_mode.inbox_folder);
-        let arc = context.configured_mvbox_folder_override.clone();
-        let mut mutex_guard = arc.lock().unwrap();
-        *mutex_guard = deltachat_mode.configured_mvbox_folder_override;
+        let coi_deltachat_mode =
+            context
+                .get_coi_config()
+                .map(|config| config.get_coi_deltachat_mode())
+                .unwrap_or_default();
+
+        inbox.set_watch_folder(coi_deltachat_mode.get_inbox_folder_override().unwrap_or("INBOX").into());
+        context.set_coi_deltachat_mode(coi_deltachat_mode);
     }
     ret_connected
 }

--- a/src/job_thread.rs
+++ b/src/job_thread.rs
@@ -121,12 +121,9 @@ impl JobThread {
             JobThreadKind::SentBox => "configured_sentbox_folder",
             JobThreadKind::MoveBox => "configured_mvbox_folder",
         };
-        {
-            let arc = context.configured_mvbox_folder_override.clone();
-            let mutex_guard = arc.lock().unwrap();
-            if let Some(ref mvbox_folder_override) = *mutex_guard {
-                return Some(mvbox_folder_override.into());
-            }
+
+        if let Some(mvbox_folder_override) = context.get_mvbox_folder_override() {
+            return Some(mvbox_folder_override);
         }
  
         if let Some(mvbox_name) = context.sql.get_config(context, folder_config_name) {

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -259,6 +259,11 @@ impl Sql {
         self.get_config(context, key).and_then(|s| s.parse().ok())
     }
 
+    /// Treats an integer value of "0" as false and any other integer value as true.
+    pub fn get_config_bool(&self, context: &Context, key: impl AsRef<str>) -> Option<bool> {
+        self.get_config_int(context, key).map(|value| value != 0)
+    }
+
     pub fn set_config_int64(
         &self,
         context: &Context,


### PR DESCRIPTION
* Store all information that influence Deltachat's behavior in case COI
  is present in struct `CoiDeltachatMode`.

* Access `CoiDeltachatMode` via a Mutex. No fancy AtomicBool anymore.
  Performance doesn't really matter here.

* Refactor some commonly used code into `mvbox_use_network()`. We might
  want to override the database settings in case of COI.

* CoiConfig - hardcode imap delimiter to '/'.  AFAIK, there is no way to
  determine which IMAP delimiter a server uses.  For COI we can assume a
  Dovecot server. But this is a more general problem and has to be
  solved on a higer level.