### PR TITLE
OT-436: Broken Pipe IO Error in IMAP IDLE

### DIFF
--- a/src/imap.rs
+++ b/src/imap.rs
@@ -1148,6 +1148,12 @@ impl Imap {
                 idle.wait_interruptible()
             })();
             match res {
+                Err(imap::error::Error::Io(ref err))
+                    if err.kind() == std::io::ErrorKind::BrokenPipe =>
+                {
+                    info!(context, 0, "IMAP-IDLE wait cancelled, we will reconnect soon.");
+                    self.should_reconnect.store(true, Ordering::Relaxed);
+                },
                 Err(imap::error::Error::ConnectionLost) => {
                     info!(context, 0, "IMAP-IDLE wait cancelled, we will reconnect soon.");
                     self.should_reconnect.store(true, Ordering::Relaxed);

--- a/src/imap.rs
+++ b/src/imap.rs
@@ -1148,12 +1148,7 @@ impl Imap {
                 idle.wait_interruptible()
             })();
             match res {
-                Err(imap::error::Error::Io(ref err))
-                    if err.kind() == std::io::ErrorKind::BrokenPipe =>
-                {
-                    info!(context, 0, "IMAP-IDLE wait cancelled, we will reconnect soon.");
-                    self.should_reconnect.store(true, Ordering::Relaxed);
-                },
+                Err(imap::error::Error::Io(_)) |
                 Err(imap::error::Error::ConnectionLost) => {
                     info!(context, 0, "IMAP-IDLE wait cancelled, we will reconnect soon.");
                     self.should_reconnect.store(true, Ordering::Relaxed);


### PR DESCRIPTION
Root cause: In addition to the custom ConnectionLost error which was raised when a read returned 0 bytes, The standard IO BrokenPipe error can be raised when the connection was terminated.

Solution: Handle both ConnectionLost and BrokenPipe the same way.

Question: Is there a nice way to write the `match` which avoids the added redundancy?
